### PR TITLE
maven 3.9.9 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,2 @@
+XCOPY "." "%LIBRARY_PREFIX%" /e
 rd /s /q "%LIBRARY_PREFIX%\lib\ext\"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,1 @@
-XCOPY "." "%LIBRARY_PREFIX%" /e
-
 rd /s /q "%LIBRARY_PREFIX%\lib\ext\"
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,4 +9,3 @@ cd $PREFIX/bin
 ln -s ../opt/maven/bin/* .
 
 rm -fr $target/lib/ext/
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ test:
 
 about:
   home: https://maven.apache.org
-  license: Apachev2
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: A software project management and comprehension tool.
@@ -31,6 +31,8 @@ about:
     Apache Maven is a software project management and comprehension tool.
     Based on the concept of a project object model (POM), Maven can manage
     a project's build, reporting and documentation from a central piece of information.
+  dev_url: https://github.com/apache/maven
+  doc_url: https://maven.apache.org/guides/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://dlcdn.apache.org/maven/maven-3/{{ version }}/binaries/apache-maven-{{ version }}-bin.tar.gz
-  sha256: 8a24c448d4ac397e6b0c019a4d7250068c02d1cdb553299e6bb71c3ccca78b2c
+  sha256: 7a9cdf674fc1703d6382f5f330b3d110ea1b512b51f1652846d9e4e8a588d766
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [s390x]
 
 requirements:
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,16 @@
-{% set version = "3.8.1" %}
+{% set name = "maven" %}
+{% set version = "3.9.9" %}
 
 package:
-  name: maven
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: apache-maven-{{ version }}-bin.tar.gz
-  url: http://apache.hippo.nl/maven/maven-3/{{ version }}/binaries/apache-maven-{{ version }}-bin.tar.gz
-  sha256: b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
+  url: https://dlcdn.apache.org/maven/maven-3/{{ version }}/binaries/apache-maven-{{ version }}-bin.tar.gz
+  sha256: 8a24c448d4ac397e6b0c019a4d7250068c02d1cdb553299e6bb71c3ccca78b2c
 
 build:
   number: 0
-  # Ignore some non-x86_64 platforms due to missing OpenJDKs
-  skip: True  # [win32 or (not x86 and not (linux and aarch64))]
-  missing_dso_whitelist:
-    # package includes libjansi DSO for various platforms, ignore them
-    - '**libutil.so.1'
-    - '**libutil.so.9'
-    - '**libc.so.6'
-    - '**libc.so.7'
-    - '**libSystem.B.dylib'
 
 requirements:
   run:


### PR DESCRIPTION
maven 3.9.9 

**Destination channel:** Defaults

### Links

- [PKG-5666]
- dev_url:        https://github.com/apache/maven-sources
- conda_forge:    https://github.com/conda-forge/maven-feedstock
- pypi:           n/a
- pypi inspector: n/a
- Dependency for:
    - https://github.com/AnacondaRecipes/antlr-feedstock/pull/1

### Explanation of changes:

- 3.9.9 build for antlr


[PKG-5666]: https://anaconda.atlassian.net/browse/PKG-5666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ